### PR TITLE
Patches for vl environment #DATE20-4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,44 @@ build.ninja
 cscope.*
 __pycache__/
 cmake/Cooking.cmake
+
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+.idea/
+cmake-build-debug/
+settings
+
+make_install
+build

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -914,7 +914,7 @@ bool cpu_pages::initialize() {
     assert(cpu_id < max_cpus);
     all_cpus[cpu_id] = this;
     auto base = mem_base() + (size_t(cpu_id) << cpu_id_shift);
-    auto size = 32 << 20;  // Small size for bootstrap
+    auto size = 32 << 23;  // Small size for bootstrap
     auto r = ::mmap(base, size,
             PROT_READ | PROT_WRITE,
             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -21,7 +21,7 @@
 
 #include <random>
 
-#include <linux/if.h>
+#include <net/if.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <net/route.h>


### PR DESCRIPTION
Need to make a couple changes to get this framework to work for us.

- increase the capacity for allocations
- until we upgrade our linux kernels we need to #include <net/if.h> instead of  <linux/if.h>

[DATE20-4](https://vibelife.myjetbrains.com/youtrack/issue/DATE20-4)
